### PR TITLE
add yapf post-gen hook to recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The fastest most convenient way for getting started with developing AiiDA plugin
 
 ## Usage
 
-    pip install cookiecutter
+    pip install cookiecutter yapf
     cookiecutter https://github.com/aiidateam/aiida-plugin-cutter.git
 
 ![Demo](https://image.ibb.co/ct6rL8/aiida_plugin_cutter.gif "The fastest way to kickstart an AiiDA plugin.")

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if hash yapf 2>/dev/null; then
+    echo "Running yapf formatter..."
+    yapf -i -r '../{{ cookiecutter.plugin_name }}/'
+fi


### PR DESCRIPTION
fix #24

this simplifies cookiecutter development, since the template itself
no longer needs to produce perfect yapf output (the post-gen hook
will take care of it)

Note: This means that users of the plugin-cutter will need to install yapf as well. It's now part of the `pip install` they anyhow need to do. 
If `yapf` is missing, the post-gen hook will silently do nothing and the user ends up with a plugin that is not perfectly formatted - we can live with that.