### PR TITLE
🐛 FIX:  `pyproject.toml` author whitespace

### DIFF
--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -8,11 +8,11 @@ build-backend = "flit_core.buildapi"
 name = "{{cookiecutter.plugin_name}}"
 dynamic = ["version"]  # read from {{cookiecutter.module_name}}/__init__.py
 description = "{{cookiecutter.short_description}}"
-{%- if cookiecutter.contact_email -%}
+{%- if cookiecutter.contact_email %}
 authors = [{name = "{{cookiecutter.author}}", email = "{{cookiecutter.contact_email}}"}]
 {% else %}
 authors = [{name = "{{cookiecutter.author}}"}]
-{%- endif %}
+{% endif -%}
 readme = "README.md"
 license = {file = "LICENSE"}
 classifiers = [


### PR DESCRIPTION
In case the user specifies an email, the current formatting was causing the
`authors` to be on the same line as `description`, which caused the following
error:

```
Running black on aiida-diff
Error: Could not open file /home/aiida/envs/aiida-super/code/aiida-diff/pyproject.toml: Error reading configuration file: Expected newline or end of document after a statement (at line 10, column 115)
```