### PR TITLE
relax dependency constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
         # Change plugin_name to test we're not specific to "aiida-diff"
         cookiecutter --no-input . plugin_name=${PLUGIN_NAME}
         pip install -e ${PLUGIN_NAME}[testing]
-        reentry scan -r aiida
       env:
         PLUGIN_NAME: aiida-ck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        backend: ['django']
+        backend: ['sqlalchemy']
         aiida-version: ['stable', 'develop']
     services:
       postgres:
@@ -53,6 +53,10 @@ jobs:
         pip install -e ${PLUGIN_NAME}[testing]
       env:
         PLUGIN_NAME: aiida-ck
+
+    - name: Run reentry scan
+      run: reentry scan
+      if: ${{ matrix.aiida-version != 'develop' }}
 
     - name: Run test suite
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       postgres:
         image: postgres:10
         env:
-          POSTGRES_DB: test_${{ matrix.backend }}
+          POSTGRES_DB: test_aiida
           POSTGRES_PASSWORD: ''
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        backend: ['sqlalchemy']
         aiida-version: ['stable', 'develop']
     services:
       postgres:
@@ -60,7 +59,6 @@ jobs:
 
     - name: Run test suite
       env:
-        AIIDA_TEST_BACKEND: ${{ matrix.backend }}
         # show timings of tests
         PYTEST_ADDOPTS: "--durations=0"
         PLUGIN_NAME: aiida-ck

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,6 @@
   "contact_email": "",
   "version": "0.1.0a0",
   "author": "The AiiDA Team",
-  "aiida_min_version": "1.1.0",
+  "aiida_min_version": "1.6.4",
   "year": "2022"
 }

--- a/{{cookiecutter.plugin_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8"]
-        backend: ['django']
+        aiida-version: ["stable", "develop"]
 
     services:
       postgres:
         image: postgres:10
         env:
-          POSTGRES_DB: test_${{ '{{ matrix.backend }}' }}
+          POSTGRES_DB: test_aiida
           POSTGRES_PASSWORD: ''
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
@@ -39,15 +39,22 @@ jobs:
       with:
         python-version: ${{ '{{ matrix.python-version }}' }}
 
+    - name: Install aiida develop version
+      run: |
+        pip install git+git://github.com/aiidateam/aiida-core
+      if: ${{ matrix.aiida-version == 'develop' }}
+
     - name: Install python dependencies
       run: |
         pip install --upgrade pip
         pip install -e .[testing]
-        reentry scan -r aiida
+
+    - name: Run reentry scan
+      run: reentry scan
+      if: ${{ matrix.aiida-version != 'develop' }}
 
     - name: Run test suite
       env:
-        AIIDA_TEST_BACKEND: ${{ '{{ matrix.backend }}' }}
         # show timings of tests
         PYTEST_ADDOPTS: "--durations=0"
       run: pytest --cov {{cookiecutter.module_name}} --cov-append .

--- a/{{cookiecutter.plugin_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install aiida develop version
       run: |
         pip install git+git://github.com/aiidateam/aiida-core
-      if: ${{ matrix.aiida-version == 'develop' }}
+      if: ${{ '{{ matrix.aiida-version == 'develop' }}' }}
 
     - name: Install python dependencies
       run: |
@@ -51,7 +51,7 @@ jobs:
 
     - name: Run reentry scan
       run: reentry scan
-      if: ${{ matrix.aiida-version != 'develop' }}
+      if: ${{ '{{ matrix.aiida-version != 'develop' }}' }}
 
     - name: Run test suite
       env:

--- a/{{cookiecutter.plugin_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install aiida develop version
       run: |
         pip install git+git://github.com/aiidateam/aiida-core
-      if: ${{ '{{ matrix.aiida-version == 'develop' }}' }}
+      if: ${{ '{{ matrix.aiida-version == "develop" }}' }}
 
     - name: Install python dependencies
       run: |
@@ -51,7 +51,7 @@ jobs:
 
     - name: Run reentry scan
       run: reentry scan
-      if: ${{ '{{ matrix.aiida-version != 'develop' }}' }}
+      if: ${{ '{{ matrix.aiida-version != "develop" }}' }}
 
     - name: Run test suite
       env:

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -26,9 +26,7 @@ classifiers = [
 keywords = ["aiida", "plugin"]
 requires-python = ">=3.7"
 dependencies = [
-    "aiida-core>={{cookiecutter.aiida_min_version}},<2.0.0",
-    "sqlalchemy<1.4",
-    "psycopg2-binary<2.9",
+    "aiida-core>={{cookiecutter.aiida_min_version}},<3",
     "voluptuous"
 ]
 

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -49,7 +49,8 @@ docs = [
     "sphinx",
     "sphinxcontrib-contentui",
     "sphinxcontrib-details-directive",
-    "furo"
+    "furo",
+    "markupsafe<2.1"
 ]
 
 [project.entry-points."aiida.data"]


### PR DESCRIPTION
Drop/relax dependency constraints in preparation for AiiDA 2.0.

 - aiida-core 1.6.0 already pinned sqlalchemy
   (but that version won't work for aiida-core 2.0)
 - aiida-core 1.6.4 already pinned psycopg2-binary
   (but that version won't work for aiida-core 2.0)