### PR TITLE
Fix entry point name in `get_computer`

### DIFF
--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/helpers.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/helpers.py
@@ -56,8 +56,8 @@ def get_computer(name=LOCALHOST_NAME, workdir=None):
             description="localhost computer set up by aiida_diff tests",
             hostname=name,
             workdir=workdir,
-            transport_type="local",
-            scheduler_type="direct",
+            transport_type="core.local",
+            scheduler_type="core.direct",
         )
         computer.store()
         computer.set_minimum_job_poll_interval(0.0)


### PR DESCRIPTION
Since AiiDA>=2.0, all entry points provided by aiida-core start with
`core.` prefix. This commit fixes old entry point names for localhost
computer.

See https://aiida.readthedocs.io/projects/aiida-core/en/latest/reference/_changelog.html?highlight=scheduler#plugin-entry-point-updates