### PR TITLE
fix: leave handling MPI setup to AiiDA

### DIFF
--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/calculations.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/calculations.py
@@ -71,7 +71,6 @@ class DiffCalculation(CalcJob):
         )
         codeinfo.code_uuid = self.inputs.code.uuid
         codeinfo.stdout_name = self.metadata.options.output_filename
-        codeinfo.withmpi = self.inputs.metadata.options.withmpi
 
         # Prepare a `CalcInfo` to be returned to the engine
         calcinfo = datastructures.CalcInfo()


### PR DESCRIPTION
AiiDA already takes care of setting `withmpi` in the `CodeInfo` appropriately. Manually copying over the value from `metadata.options.withmpi` prevents AiiDA from distinguishing between a default value and a value provided by the user.