### PR TITLE
RTD: Add explicit Sphinx configuration

### DIFF
--- a/{{cookiecutter.plugin_name}}/.readthedocs.yml
+++ b/{{cookiecutter.plugin_name}}/.readthedocs.yml
@@ -11,3 +11,8 @@ python:
       path: .
       extra_requirements:
         - docs
+
+sphinx:
+    builder: html
+    configuration: docs/source/conf.py
+    fail_on_warning: true


### PR DESCRIPTION
Since Jan 2025 RTD projects must explicitly define the configuration, see:

https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/